### PR TITLE
Fix for virtualization/get_interface

### DIFF
--- a/netbox/dcim.py
+++ b/netbox/dcim.py
@@ -325,6 +325,10 @@ class Dcim(object):
         """Return interfaces"""
         return self.netbox_con.get('/dcim/interfaces', **kwargs)
 
+    def get_interface(self, interface_id, **kwargs):
+        """Return interface by id"""
+        return self.netbox_con.get('/dcim/interfaces/' + str(interface_id) + '/', **kwargs)
+
     def create_interface(self, name, form_factor, device_id, **kwargs):
         """Create a new interface
 

--- a/netbox/virtualization.py
+++ b/netbox/virtualization.py
@@ -88,9 +88,9 @@ class Virtualization(object):
         """Return all interfaces"""
         return self.netbox_con.get('/virtualization/interfaces/', **kwargs)
 
-    def get_interface(self, **kwargs):
-        """Return interface by filter"""
-        return self.netbox_con.get('/virtualization/interfaces/', **kwargs)
+    def get_interface(self, interface_id, **kwargs):
+        """Return interface by id"""
+        return self.netbox_con.get('/virtualization/interfaces/' + str(interface_id) + '/', **kwargs)
 
     def create_interface(self, name, virtual_machine, **kwargs):
         """Create an interface for a virtual machine


### PR DESCRIPTION
The Netbox API expects the request to be like http://servername/api/virtualization/interfaces/{id}/,
everything else returns all virtual interfaces known to Netbox