### PR TITLE
Stringify kwargs before escaping them

### DIFF
--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -82,7 +82,7 @@ class NetboxConnection(object):
 
         if kwargs:
             url = '{}{}?{}&limit={}'.format(self.base_url, param,
-                                            '&'.join('{}={}'.format(key, urllib.parse.quote(val)) for key, val in kwargs.items()), limit)
+                                            '&'.join('{}={}'.format(key, urllib.parse.quote(str(val))) for key, val in kwargs.items()), limit)
         elif key:
             if '_choices' in param:
                 url = '{}{}{}/?limit={}'.format(self.base_url, param, key, limit)


### PR DESCRIPTION
kwargs can contain numeric values that `urllib.parse.quote()` doesn't properly escape because they aren't strings. Force these to be escaped as strings.

This fixes https://github.com/jagter/python-netbox/issues/42