### PR TITLE
Fixing issue in https://github.com/jagter/python-netbox/issues/51

### DIFF
--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -93,7 +93,10 @@ class NetboxConnection(object):
 
         resp_data = self.__request('GET', params=param, key=key, url=url)
 
-        return resp_data
+        if resp_data.get('results', None):
+            return resp_data['results']
+        else:
+            return resp_data
 
     def put(self, params):
 

--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -93,7 +93,7 @@ class NetboxConnection(object):
 
         resp_data = self.__request('GET', params=param, key=key, url=url)
 
-        return resp_data['results']
+        return resp_data
 
     def put(self, params):
 


### PR DESCRIPTION
This will fix the issue mentioned in https://github.com/jagter/python-netbox/issues/51. Issue is tied to the "results" key not being present in the response from the API. Example of API response below:
```
>>> import requests
>>> url = "http://localhost:8000/api/ipam/prefixes/2/available-ips"
>>> head = {"Authorization": "Token 0123456789abcdef0123456789abcdef01234567"}
>>> requests.get(url, headers=head).json()
[{'family': 4, 'address': '10.0.2.9/25', 'vrf': None}]
>>>
```