### PR TITLE
return raw result if export template is specified

### DIFF
--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -71,7 +71,7 @@ class NetboxConnection(object):
         if response.status_code == 204:
             return response.content
 
-        if(method == "GET" and "export" in params):
+        if(method == "GET" and "&export=" in url):
             # return raw result if export template is specified
             return {"results": response.text}
 

--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -71,6 +71,10 @@ class NetboxConnection(object):
         if response.status_code == 204:
             return response.content
 
+        if(method == "GET" and "export" in params):
+            # return raw result if export template is specified
+            return {"results": response.text}
+
         try:
             response_data = response.json()
         except json.JSONDecodeError:

--- a/netbox/connection.py
+++ b/netbox/connection.py
@@ -71,7 +71,7 @@ class NetboxConnection(object):
         if response.status_code == 204:
             return response.content
 
-        if(method == "GET" and "&export=" in url):
+        if(method == "GET" and ("&export=" in url or "?export=" in url)):
             # return raw result if export template is specified
             return {"results": response.text}
 


### PR DESCRIPTION
If an export template is used, the json conversion will fail. 

This will return the raw response data for this case